### PR TITLE
Make Circle CI test against merge with PR base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,22 @@ common: &common
   working_directory: ~/repo
   steps:
     - checkout
+    - run:
+        name: merge pull request base
+        command: |
+          if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+            PR_INFO_URL=https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER
+
+            PR_BASE_BRANCH=$(curl -L "$PR_INFO_URL" | python -c 'import json, sys; obj = json.load(sys.stdin); sys.stdout.write(obj["base"]["ref"])')
+            git fetch origin +"$PR_BASE_BRANCH":circleci/pr-base
+
+            # We need these config values or git complains when creating the
+            # merge commit
+            git config --global user.name "Circle CI"
+            git config --global user.email "circleci@example.com"
+
+            git merge --no-edit circleci/pr-base
+          fi
     - restore_cache:
         keys:
           - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}


### PR DESCRIPTION
## What was wrong?

Current Circle CI config does not test against merge with PR base branch.

## How was it fixed?

Updated Circle CI config to add build step to create merge commit with base branch if testing a pull request.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://photos1.blogger.com/blogger/2706/3096/1600/cuteanimal02.4.jpg)