### PR TITLE
Use twine for pypi uploading per packaging docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 dist: clean

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ extras_require = {
         "bumpversion>=0.5.3,<1",
         "pytest-watch>=4.1.0,<5",
         "wheel",
+        "twine",
         "ipython",
     ],
 }


### PR DESCRIPTION
It seems the official python packaging docs favor using twine which does seem a bit less error prone in my experience.

See here:
https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives