### PR TITLE
Fix ineffectual commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CURRENT_SIGN_SETTING := $(shell git config commit.gpgSign)
+
 .PHONY: clean-pyc clean-build docs
 
 help:
@@ -47,7 +49,6 @@ linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
 release: clean
-	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags


### PR DESCRIPTION
In Makefile, `CURRENT_SIGN_SETTING` was being set to `""`, then set locally which effectively erases the user's current signing setting.